### PR TITLE
feat(backend/accounts): add accounts endpoints & data models

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -9,6 +9,7 @@ from .config import Config
 from .routers import (
     status,
     create_user,
+    create_account,
 )
 
 
@@ -41,5 +42,6 @@ def create_app(config: Optional[Config] = None) -> FastAPI:
 
     app.include_router(status)
     app.include_router(create_user(config))
+    app.include_router(create_account(config))
 
     return app

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,5 +1,12 @@
 """Data model objects."""
 
+from .account import (
+    AccountChanges,
+    AccountIn,
+    AccountNewDb,
+    AccountOut,
+    AccountModel,
+)
 from .user import (
     UserChanges,
     UserIn,
@@ -7,4 +14,14 @@ from .user import (
     UserModel,
 )
 
-__all__ = ["UserChanges", "UserIn", "UserOut", "UserModel"]
+__all__ = [
+    "AccountChanges",
+    "AccountIn",
+    "AccountNewDb",
+    "AccountOut",
+    "AccountModel",
+    "UserChanges",
+    "UserIn",
+    "UserOut",
+    "UserModel",
+]

--- a/backend/src/models/account.py
+++ b/backend/src/models/account.py
@@ -50,10 +50,11 @@ class AccountModel(DummyModel):
         async def many_by_user(
             self, user_id: UUID, closed: bool = False
         ) -> list[AccountOut]:
+            """Return accounts for the given user, filtered by closed status."""
             raise NotImplementedError("TODO...")
 
     read: Read
 
     def __init__(self) -> None:
-        super()
+        super().__init__()
         self.read = AccountModel.Read()

--- a/backend/src/models/account.py
+++ b/backend/src/models/account.py
@@ -1,0 +1,59 @@
+"""Account* data objects."""
+
+from uuid import UUID
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .dummy_model import DummyModel
+
+
+class AccountBase(BaseModel):
+    """Common fields for user Accounts."""
+
+    name: str
+    closed: bool
+
+
+class AccountIn(AccountBase):
+    """Fields needed from user to create an Account."""
+
+    closed: bool = False
+
+
+class AccountChanges(AccountBase):
+    """Fields used when updating an Account, all are optional."""
+
+    name: Optional[str] = None
+    closed: Optional[bool] = None
+
+
+class AccountNewDb(AccountBase):
+    """Information needed to save a new account to the database."""
+
+    user_id: UUID
+
+
+class AccountOut(AccountNewDb):
+    """Fields returned by Account queries."""
+
+    id: UUID
+
+
+class AccountModel(DummyModel):
+    """Dummy ORM for Account objects."""
+
+    class Read(DummyModel.Read):
+        """Add read many by user method."""
+
+        async def many_by_user(
+            self, user_id: UUID, closed: bool = False
+        ) -> list[AccountOut]:
+            raise NotImplementedError("TODO...")
+
+    read: Read
+
+    def __init__(self) -> None:
+        super()
+        self.read = AccountModel.Read()

--- a/backend/src/routers/__init__.py
+++ b/backend/src/routers/__init__.py
@@ -1,6 +1,7 @@
 """Sub Routers."""
 
-from src.routers.status import status
-from src.routers.user import create_user
+from .status import status
+from .user import create_user
+from .account import create_account
 
-__all__ = ["status", "create_user"]
+__all__ = ["status", "create_account", "create_user"]

--- a/backend/src/routers/account.py
+++ b/backend/src/routers/account.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import status as status_code, Depends
+from fastapi import status as status_code
 from fastapi.routing import APIRouter
 
 from src.config import Config
@@ -33,7 +33,7 @@ def create_account(config: Config) -> APIRouter:
     async def post(new_account: AccountIn, user_id: UUID) -> AccountOut:
         """Create a new account for given User."""
         return await model.create.new(
-            AccountNewDb(**new_account.dict(), user_id=user_id)
+            AccountNewDb(**new_account.model_dump(), user_id=user_id)
         )
 
     @account.get(

--- a/backend/src/routers/account.py
+++ b/backend/src/routers/account.py
@@ -1,0 +1,76 @@
+"""Routes under `/account`."""
+
+from uuid import UUID
+
+from fastapi import status as status_code, Depends
+from fastapi.routing import APIRouter
+
+from src.config import Config
+from src.models import (
+    AccountChanges,
+    AccountIn,
+    AccountNewDb,
+    AccountOut,
+    AccountModel,
+)
+
+
+def create_account(config: Config) -> APIRouter:
+    """Create a account router & model with access to the given database."""
+    # setup db & Account model
+    model = AccountModel()
+
+    # set up account router
+    account = APIRouter(prefix="/account", tags=["Account"])
+
+    # add routes
+    @account.post(
+        "",
+        response_model=AccountOut,
+        status_code=status_code.HTTP_201_CREATED,
+        summary="Create a new Account for the currently authenticated User.",
+    )
+    async def post(new_account: AccountIn, user_id: UUID) -> AccountOut:
+        """Create a new account for given User."""
+        return await model.create.new(
+            AccountNewDb(**new_account.dict(), user_id=user_id)
+        )
+
+    @account.get(
+        "",
+        response_model=list[AccountOut],
+        summary="Get the Accounts for the currently authenticated User.",
+    )
+    async def get(user_id: UUID) -> list[AccountOut]:
+        """Read all open accounts for given User."""
+        return await model.read.many_by_user(user_id)
+
+    @account.put(
+        "/{account_id}", response_model=AccountOut, summary="Update the given Account."
+    )
+    async def put_id(
+        account_id: UUID, changes: AccountChanges, user_id: UUID
+    ) -> AccountOut:
+        """Update the given account with the given changes."""
+        return await model.update.changes(account_id, changes)
+
+    @account.put(
+        "/{account_id}/closed",
+        response_model=AccountOut,
+        summary="Mark the given Account as closed.",
+    )
+    async def put_closed(account_id: UUID, user_id: UUID) -> AccountOut:
+        """Mark the given account as closed."""
+        return await model.update.changes(account_id, AccountChanges(closed=True))
+
+    @account.get(
+        "/closed",
+        response_model=list[AccountOut],
+        summary="Get all closed Accounts for current User.",
+    )
+    async def get_closed(user_id: UUID) -> list[AccountOut]:
+        """Mark the given account as closed."""
+        return await model.read.many_by_user(user_id, closed=True)
+
+    # return router
+    return account

--- a/backend/src/routers/test_account.py
+++ b/backend/src/routers/test_account.py
@@ -1,0 +1,274 @@
+"""Tests for /account routes."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.app import create_app
+from src.models import AccountOut
+
+_TEST_USER_ID = uuid4()
+_TEST_ACCOUNT_ID = uuid4()
+
+
+class TestPostAccount(unittest.TestCase):
+    """Tests for POST /account."""
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.app = create_app()
+        self.client = TestClient(self.app)
+
+    def test_valid_data_returns_201_with_account_out(self) -> None:
+        """POST with valid data returns 201 and an AccountOut with matching fields."""
+        expected = AccountOut(
+            id=_TEST_ACCOUNT_ID,
+            user_id=_TEST_USER_ID,
+            name="Test Account",
+            closed=False,
+        )
+
+        with patch(
+            "src.models.dummy_model.DummyModel.Create.new",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ):
+            response = self.client.post(
+                "/account",
+                params={"user_id": str(_TEST_USER_ID)},
+                json={"name": "Test Account"},
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["name"], "Test Account")
+        self.assertEqual(data["closed"], False)
+        self.assertEqual(data["user_id"], str(_TEST_USER_ID))
+        self.assertIn("id", data)
+
+    def test_missing_required_field_returns_422(self) -> None:
+        """POST without required name field returns 422 with error detail."""
+        response = self.client.post(
+            "/account",
+            params={"user_id": str(_TEST_USER_ID)},
+            json={},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+    def test_invalid_field_type_returns_422(self) -> None:
+        """POST with an invalid field type returns 422 with error detail."""
+        response = self.client.post(
+            "/account",
+            params={"user_id": "not-a-valid-uuid"},
+            json={"name": "Test Account"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+
+class TestGetAccount(unittest.TestCase):
+    """Tests for GET /account."""
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.app = create_app()
+        self.client = TestClient(self.app)
+
+    def test_valid_user_id_returns_200_with_account_list(self) -> None:
+        """GET with valid user_id returns 200 and a list of AccountOut."""
+        expected = [
+            AccountOut(
+                id=_TEST_ACCOUNT_ID,
+                user_id=_TEST_USER_ID,
+                name="Test Account",
+                closed=False,
+            )
+        ]
+
+        with patch(
+            "src.models.account.AccountModel.Read.many_by_user",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ):
+            response = self.client.get(
+                "/account",
+                params={"user_id": str(_TEST_USER_ID)},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "Test Account")
+        self.assertEqual(data[0]["closed"], False)
+
+    def test_invalid_user_id_returns_422(self) -> None:
+        """GET with invalid user_id returns 422 with error detail."""
+        response = self.client.get(
+            "/account",
+            params={"user_id": "not-a-valid-uuid"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+
+class TestPutAccountId(unittest.TestCase):
+    """Tests for PUT /{account_id}."""
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.app = create_app()
+        self.client = TestClient(self.app)
+
+    def test_valid_data_returns_200_with_updated_account(self) -> None:
+        """PUT with valid data returns 200 and the updated AccountOut."""
+        expected = AccountOut(
+            id=_TEST_ACCOUNT_ID,
+            user_id=_TEST_USER_ID,
+            name="Updated Account",
+            closed=False,
+        )
+
+        with patch(
+            "src.models.dummy_model.DummyModel.Update.changes",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ):
+            response = self.client.put(
+                f"/account/{_TEST_ACCOUNT_ID}",
+                params={"user_id": str(_TEST_USER_ID)},
+                json={"name": "Updated Account"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["name"], "Updated Account")
+        self.assertEqual(data["id"], str(_TEST_ACCOUNT_ID))
+
+    def test_invalid_account_id_returns_422(self) -> None:
+        """PUT with an invalid account_id path param returns 422 with error detail."""
+        response = self.client.put(
+            "/account/not-a-valid-uuid",
+            params={"user_id": str(_TEST_USER_ID)},
+            json={"name": "Updated Account"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+    def test_missing_user_id_returns_422(self) -> None:
+        """PUT without user_id query param returns 422 with error detail."""
+        response = self.client.put(
+            f"/account/{_TEST_ACCOUNT_ID}",
+            json={"name": "Updated Account"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+
+class TestPutAccountClosed(unittest.TestCase):
+    """Tests for PUT /{account_id}/closed."""
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.app = create_app()
+        self.client = TestClient(self.app)
+
+    def test_valid_account_id_returns_200_with_closed_account(self) -> None:
+        """Valid account_id: returns 200 with AccountOut where closed=True."""
+        expected = AccountOut(
+            id=_TEST_ACCOUNT_ID,
+            user_id=_TEST_USER_ID,
+            name="Test Account",
+            closed=True,
+        )
+
+        with patch(
+            "src.models.dummy_model.DummyModel.Update.changes",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ):
+            response = self.client.put(
+                f"/account/{_TEST_ACCOUNT_ID}/closed",
+                params={"user_id": str(_TEST_USER_ID)},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["closed"], True)
+        self.assertEqual(data["id"], str(_TEST_ACCOUNT_ID))
+
+    def test_invalid_account_id_returns_422(self) -> None:
+        """Invalid account_id path param: returns 422 with error detail."""
+        response = self.client.put(
+            "/account/not-a-valid-uuid/closed",
+            params={"user_id": str(_TEST_USER_ID)},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+
+class TestGetClosedAccounts(unittest.TestCase):
+    """Tests for GET /closed."""
+
+    def setUp(self) -> None:
+        """Set up test client."""
+        self.app = create_app()
+        self.client = TestClient(self.app)
+
+    def test_valid_user_id_returns_200_with_closed_account_list(self) -> None:
+        """Valid user_id: returns 200 with list of closed AccountOut."""
+        expected = [
+            AccountOut(
+                id=_TEST_ACCOUNT_ID,
+                user_id=_TEST_USER_ID,
+                name="Closed Account",
+                closed=True,
+            )
+        ]
+
+        with patch(
+            "src.models.account.AccountModel.Read.many_by_user",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ):
+            response = self.client.get(
+                "/account/closed",
+                params={"user_id": str(_TEST_USER_ID)},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["closed"], True)
+        self.assertEqual(data[0]["name"], "Closed Account")
+
+    def test_invalid_user_id_returns_422(self) -> None:
+        """GET /closed with invalid user_id returns 422 with error detail."""
+        response = self.client.get(
+            "/account/closed",
+            params={"user_id": "not-a-valid-uuid"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertIn("detail", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds endpoints & data models for creating, reading, updating, & deleting Accounts. Doesn't actually save anything yet as no database logic has been built yet.