### PR TITLE
feat(backend/security): adds jwt-based auth w/ password hashing done in db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 .envrc
 open
+.secrets/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,0 @@
-from app import create_app
-
-app = create_app()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "db-wrapper",
     "fastapi-swagger>=0.4.48",
     "fastapi[standard]>=0.135.3",
+    "pyjwt>=2.12.1",
 ]
 
 [tool.ruff.lint]

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -11,12 +11,14 @@ from src.errors import TodoError
 from src.routers import (
     create_account,
     create_status,
+    create_token,
     create_user,
 )
 
 
 def create_app(ctx: Context = Context()) -> FastAPI:
     """Application factory to create server instance from given config."""
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         """Load database on startup & cleanup on shutdown."""
@@ -52,6 +54,7 @@ def create_app(ctx: Context = Context()) -> FastAPI:
         )
 
     app.include_router(create_status(ctx))
+    app.include_router(create_token(ctx))
     app.include_router(create_user(ctx))
     app.include_router(create_account(ctx))
 

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,6 +1,6 @@
 """Backend API Server entry point."""
 
-from typing import Optional
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -17,7 +17,15 @@ from src.routers import (
 
 def create_app(ctx: Context = Context()) -> FastAPI:
     """Application factory to create server instance from given config."""
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Load database on startup & cleanup on shutdown."""
+        await ctx.database.connect()
+        yield
+        await ctx.database.disconnect()
+
     app = FastAPI(
+        lifespan=lifespan,
         root_path=ctx.root_path,
         # disable built-in docs/static paths, then...
         docs_url=None,

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -21,3 +21,5 @@ class Config:
     db_user: str = os.getenv("DB_USER", "postgres")
     db_password: str = os.getenv("DB_PASSWORD", "postgres")
 
+    # application key used for auth token signing
+    jwt_key: str | None = os.getenv("APP_KEY")

--- a/backend/src/context.py
+++ b/backend/src/context.py
@@ -1,6 +1,7 @@
 """Shared state used accross the application."""
 
 from .config import Config
+from .database import Client, create_client, create_conn_config
 
 
 class Context:
@@ -11,10 +12,17 @@ class Context:
     - database client
     """
 
-    # FIXME: have this hold a database connection when that's implemented!
-    database: bool
+    database: Client
     root_path: str
 
     def __init__(self, config: Config = Config()) -> None:
-        self.database = True
+        self.database = create_client(
+            create_conn_config(
+                user=config.db_user,
+                password=config.db_password,
+                host=config.db_host,
+                port=config.db_port,
+                database=config.db_name,
+            )
+        )
         self.root_path = config.root_path

--- a/backend/src/context.py
+++ b/backend/src/context.py
@@ -14,6 +14,7 @@ class Context:
 
     database: Client
     root_path: str
+    jwt_key: str
 
     def __init__(self, config: Config = Config()) -> None:
         self.database = create_client(
@@ -26,3 +27,31 @@ class Context:
             )
         )
         self.root_path = config.root_path
+
+        if config.jwt_key is None:
+            self.jwt_key = _get_app_key_from_file()
+        else:
+            self.jwt_key = config.jwt_key
+
+
+def _get_app_key_from_file() -> str:
+    secrets_files = (f for f in ["/run/secrets/app_key", "./.secrets/app_key.txt"])
+
+    app_key: str | None = None
+
+    # check list of paths for key
+    for path in secrets_files:
+        try:
+            with open(path, "r") as key_file:
+                app_key = str(key_file.readline())
+                # exit iteration when first key is found
+                break
+        except FileNotFoundError:
+            pass
+
+    if app_key is None:
+        raise ValueError(
+            "No value for backend Application Key found in enviornment or secrets."
+        )
+
+    return app_key

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -3,7 +3,7 @@
 from .account import (
     AccountChanges,
     AccountIn,
-    AccountNewDb,
+    AccountNew,
     AccountOut,
     AccountModel,
 )
@@ -17,7 +17,7 @@ from .user import (
 __all__ = [
     "AccountChanges",
     "AccountIn",
-    "AccountNewDb",
+    "AccountNew",
     "AccountOut",
     "AccountModel",
     "UserChanges",

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -7,6 +7,7 @@ from .account import (
     AccountOut,
     AccountModel,
 )
+from .token import Token
 from .user import (
     UserChanges,
     UserIn,
@@ -20,6 +21,7 @@ __all__ = [
     "AccountNew",
     "AccountOut",
     "AccountModel",
+    "Token",
     "UserChanges",
     "UserIn",
     "UserOut",

--- a/backend/src/models/account.py
+++ b/backend/src/models/account.py
@@ -1,15 +1,23 @@
 """Account* data objects."""
 
+from typing import Any, Optional
 from uuid import UUID
 
-from typing import Optional
+from db_wrapper.client import AsyncClient
+from db_wrapper.model import (
+    sql,
+    AsyncCreate,
+    AsyncRead,
+    AsyncUpdate,
+    AsyncModel,
+)
+from db_wrapper.model.base import NoResultFound
 
-from pydantic import BaseModel
+from .base import Base, BaseDb
+from .filters import build_query_equality_filters
 
-from .dummy_model import DummyModel
 
-
-class AccountBase(BaseModel):
+class AccountBase(Base):
     """Common fields for user Accounts."""
 
     name: str
@@ -25,36 +33,123 @@ class AccountIn(AccountBase):
 class AccountChanges(AccountBase):
     """Fields used when updating an Account, all are optional."""
 
-    name: Optional[str] = None
     closed: Optional[bool] = None
+    name: Optional[str] = None
 
 
-class AccountNewDb(AccountBase):
+class AccountNew(AccountBase):
     """Information needed to save a new account to the database."""
 
     user_id: UUID
 
 
-class AccountOut(AccountNewDb):
+class AccountOut(AccountNew, BaseDb):
     """Fields returned by Account queries."""
 
-    id: UUID
+
+class AccountCreator(AsyncCreate[AccountOut]):
+    """Extended create methods."""
+
+    async def new(self, data: AccountNew) -> AccountOut:
+        """Create a new Account."""
+        query = sql.SQL("""
+                INSERT INTO {table}(user_id, name)
+                VALUES ({user_id}, {name})
+                RETURNING *;
+                """).format(
+            table=self._table,
+            user_id=sql.Literal(str(data.user_id)),
+            name=sql.Literal(data.name),
+        )
+
+        query_result = await self._client.execute_and_return(query)
+
+        return AccountOut(**query_result[0])
 
 
-class AccountModel(DummyModel):
-    """Dummy ORM for Account objects."""
+class AccountReader(AsyncRead[AccountOut]):
+    """Extended read methods."""
 
-    class Read(DummyModel.Read):
-        """Add read many by user method."""
+    async def many_by_user(self, user_id: UUID, **kwargs: Any) -> list[AccountOut]:
+        """Get list of accounts for user."""
+        filter_values = AccountChanges(
+            **{  # type: ignore
+                # default to filtering by accounts not marked as closed
+                "closed": False,
+                # and override default if it's present in kwargs
+                **kwargs,
+            }
+        )
 
-        async def many_by_user(
-            self, user_id: UUID, closed: bool = False
-        ) -> list[AccountOut]:
-            """Return accounts for the given user, filtered by closed status."""
-            raise NotImplementedError("TODO...")
+        query = sql.SQL("""
+            SELECT * FROM {table}
+            WHERE user_id = {user_id}
+            {filters};
+        """).format(
+            table=self._table,
+            user_id=sql.Literal(str(user_id)),
+            filters=build_query_equality_filters(filter_values),
+        )
+        query_result = await self._client.execute_and_return(query)
 
-    read: Read
+        return [AccountOut(**account) for account in query_result]
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.read = AccountModel.Read()
+
+class AccountUpdater(AsyncUpdate[AccountOut]):
+    """Extended update methods."""
+
+    async def one_by_id(self, id_value: UUID, changes: dict[str, Any]) -> AccountOut:
+        """Un-implemented to force use of update.changes method."""
+        raise NotImplementedError()
+
+    async def changes(
+        self, account_id: UUID, user_id: UUID, changes: AccountChanges
+    ) -> AccountOut:
+        """Update only the given fields for the given user."""
+
+        def compose_one_change(change: tuple[str, Any]) -> sql.Composed:
+            key = change[0]
+            value = change[1]
+
+            return sql.SQL("{key} = {value}").format(
+                key=sql.Identifier(key), value=sql.Literal(value)
+            )
+
+        def compose_changes(changes: dict[str, Any]) -> sql.Composed:
+            return sql.SQL(",").join(
+                [compose_one_change(change) for change in changes.items() if change[1]]
+            )
+
+        query = sql.SQL("""
+            UPDATE {table}
+            SET {changes}
+            WHERE id = {account_id}
+            AND user_id = {user_id}
+            RETURNING *;
+        """).format(
+            table=self._table,
+            changes=compose_changes(changes.model_dump()),
+            account_id=sql.Literal(account_id),
+            user_id=sql.Literal(user_id),
+        )
+        query_result = await self._client.execute_and_return(query)
+
+        try:
+            return AccountOut(**query_result[0])
+        except IndexError as err:
+            raise NoResultFound from err
+
+
+class AccountModel(AsyncModel[AccountOut]):
+    """Account ORM."""
+
+    create: AccountCreator
+    read: AccountReader
+    update: AccountUpdater
+
+    def __init__(self, client: AsyncClient) -> None:
+        """Create Account Model."""
+        super().__init__(client, "account", AccountOut)
+        self.create = AccountCreator(client, self.table, AccountOut)
+        self.read = AccountReader(client, self.table, AccountOut)
+        self.update = AccountUpdater(client, self.table, AccountOut)

--- a/backend/src/models/filters.py
+++ b/backend/src/models/filters.py
@@ -1,0 +1,159 @@
+"""Model utility functions."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Tuple, Union
+
+from db_wrapper.model import sql
+
+from src.models.base import Base
+
+
+def _build_one_filter(
+    column: str, value: Any, comparator: sql.Composable = sql.SQL("=")
+) -> sql.Composed:
+    return sql.SQL("AND {column} {comparator} {value}").format(
+        column=sql.Identifier(column), comparator=comparator, value=sql.Literal(value)
+    )
+
+
+def build_query_equality_filters(filters: Base) -> sql.Composed:
+    """Build 'column equals value' filter arguments for query from Model."""
+    filter_queries: List[sql.Composed] = []
+
+    for key, value in filters.model_dump().items():
+        if value is not None:
+            filter_queries.append(_build_one_filter(key, value))
+
+    return sql.SQL(" ").join(filter_queries)
+
+
+Condition = Tuple[sql.Composable, Any]
+FilterQuery = Union[Condition, sql.Composed]
+FilterModel = Dict[str, FilterQuery]
+
+
+def equals(value: Any) -> Condition:
+    """Return equality value pair."""
+    return sql.SQL("="), value
+
+
+def less_than(value: Any) -> Condition:
+    """Return less than value pair."""
+    return sql.SQL("<"), value
+
+
+def greater_than(value: Any) -> Condition:
+    """Return greater than value pair."""
+    return sql.SQL(">"), value
+
+
+def less_than_or_equal_to(value: Any) -> Condition:
+    """Return less than or equal to value pair."""
+    return sql.SQL("<="), value
+
+
+def greater_than_or_equal_to(value: Any) -> Condition:
+    """Return greater than or equal to value pair."""
+    return sql.SQL(">="), value
+
+
+def is_not(pair: Condition) -> Condition:
+    """Negate a given value pair & return the query."""
+    comparator, value = pair
+    negated = sql.SQL("NOT {comparator}").format(comparator=comparator)
+
+    return negated, value
+
+
+def _build_condition(
+    column: str, value: Any, comparator: sql.Composable = sql.SQL("=")
+) -> sql.Composed:
+    literal_value = sql.Literal(value)
+
+    return sql.SQL("{column} {comparator} {value}").format(
+        column=sql.Identifier(column), comparator=comparator, value=literal_value
+    )
+
+
+class LogicalOperator(Enum):
+    """Valid SQL logical operators."""
+
+    AND = sql.SQL(" AND ")
+    OR = sql.SQL(" OR ")
+
+
+@dataclass
+class Logical:
+    """Organize data required to build a logical condition in SQL."""
+
+    operator: LogicalOperator
+    conditions: Tuple[Condition, ...]
+
+    def __init__(self, operator: LogicalOperator, *args: Condition) -> None:
+        """Create Logical from variable number of arguments as conditions."""
+        self.operator = operator
+        self.conditions = args
+
+
+def logical_or(*args: Condition) -> Logical:
+    """Combine given conditions with OR operator."""
+    return Logical(LogicalOperator.OR, *args)
+
+
+def logical_and(*args: Condition) -> Logical:
+    """Combine given conditions with AND operator."""
+    return Logical(LogicalOperator.AND, *args)
+
+
+def _build_logical(
+    log_operator: LogicalOperator,
+    *args: sql.Composable,
+) -> sql.Composable:
+    """Compose a Logical into SQL."""
+    return log_operator.value.join(list(args))
+
+
+def build_query_filters(filters: FilterModel) -> sql.SQL:
+    """Build complex filters from modified Model."""
+    filter_queries: List[sql.Composable] = []
+
+    for key, value in filters.items():
+        if isinstance(value, Logical):
+            query_filter = _build_logical(
+                value.operator,
+                *[
+                    _build_condition(key, condition, comparator)
+                    for comparator, condition in value.conditions
+                ],
+            )
+            filter_queries.append(query_filter)
+
+        elif value is not None:
+            comparator, condition = value
+
+            if condition is not None:
+                query_filter = _build_condition(key, condition, comparator)
+                filter_queries.append(query_filter)
+
+    if filter_queries:
+        composed_filter_queries = sql.SQL(" AND ").join(filter_queries)
+
+        return sql.SQL(" AND {composed}").format(composed=composed_filter_queries)
+
+    return sql.SQL("")
+
+
+def build_pagination_filters(
+    limit: int,
+    page: int,
+    sort: str,
+) -> sql.Composed:
+    """Construct SQL filters for adding pagination to a query."""
+    # offset is n times limit
+    # if limit = 50: (0, 0), (1, 50), ... (n+1, 50*n)
+    offset = page * limit
+
+    return sql.SQL(" ORDER BY {sort} DESC LIMIT {limit} OFFSET {offset} ").format(
+        sort=sql.Identifier(sort), limit=sql.Literal(limit), offset=sql.Literal(offset)
+    )

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,6 +1,6 @@
 """User* data objects."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 from uuid import UUID
 
 from db_wrapper.client import AsyncClient
@@ -15,7 +15,7 @@ from db_wrapper.model import (
 )
 from db_wrapper.model.base import NoResultFound
 
-from src.models.base import Base, BaseDb
+from .base import Base, BaseDb
 
 
 class UserBase(Base):
@@ -35,9 +35,9 @@ class UserIn(UserBase):
 class UserChanges(Base):
     """Fields used when updating a User, all are optional."""
 
-    handle: Optional[str]
-    full_name: Optional[str]
-    preferred_name: Optional[str]
+    handle: Optional[str] = None
+    full_name: Optional[str] = None
+    preferred_name: Optional[str] = None
 
     class Config:
         """Configure UserChanges Pydantic features."""
@@ -48,6 +48,19 @@ class UserChanges(Base):
 
 class UserOut(UserBase, BaseDb):
     """Fields returned by queries on User Model."""
+
+    def __eq__(self, other: object, /) -> bool:
+        """Compare UserOut objects for equality."""
+        match other:
+            case UserOut():
+                return (
+                    self.handle == other.handle
+                    and self.full_name == other.full_name
+                    and self.preferred_name == other.preferred_name
+                    and self.id == other.id
+                )
+            case _:
+                raise TypeError(f"Cannot compare type {type(self)} to {type(other)}")
 
 
 class UserDb(UserIn, BaseDb):

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,17 +1,24 @@
 """User* data objects."""
 
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
-from psycopg2.errors import UniqueViolation  # type: ignore
-from pydantic import BaseModel
+from db_wrapper.client import AsyncClient
+from db_wrapper.model import (
+    sql,
+    AsyncModel,
+    AsyncCreate,
+    AsyncRead,
+    AsyncUpdate,
+    AsyncDelete,
+    RealDictRow,
+)
+from db_wrapper.model.base import NoResultFound
 
-from src.errors import TodoError
-from .errors import DuplicateError
-from .dummy_model import DummyModel
+from src.models.base import Base, BaseDb
 
 
-class UserBase(BaseModel):
+class UserBase(Base):
     """Common fields to all User objects."""
 
     handle: str
@@ -25,51 +32,191 @@ class UserIn(UserBase):
     password: str
 
 
-class UserChanges(BaseModel):
+class UserChanges(Base):
     """Fields used when updating a User, all are optional."""
 
-    handle: Optional[str] = None
-    full_name: Optional[str] = None
-    preferred_name: Optional[str] = None
+    handle: Optional[str]
+    full_name: Optional[str]
+    preferred_name: Optional[str]
+
+    class Config:
+        """Configure UserChanges Pydantic features."""
+
+        # will now throw validation error if extra fields are given
+        extra = "forbid"
 
 
-class UserOut(UserBase):
+class UserOut(UserBase, BaseDb):
     """Fields returned by queries on User Model."""
 
-    id: UUID
 
-
-class UserDb(UserIn):
+class UserDb(UserIn, BaseDb):
     """All fields on User in database records."""
 
-    id: UUID
+
+def create_user_out(user: Dict[str, Any]) -> UserOut:
+    """Strip extraneous values from dictionary to create UserOut."""
+    return UserOut(
+        id=user["id"],
+        handle=user["handle"],
+        full_name=user["full_name"],
+        preferred_name=user["preferred_name"],
+    )
 
 
-class UserModel(DummyModel):
-    """Dummy ORM for User objects."""
+class UserCreator(AsyncCreate[UserOut]):
+    """User creation methods."""
 
-    class Create(DummyModel.Create):
-        """Create ops."""
+    async def one(self, item: UserOut) -> UserOut:
+        """Un-implemented to force use of create.new method."""
+        raise NotImplementedError()
 
-        async def new(self, obj: UserIn) -> UserOut:
-            """Save a new User to the database & return the new information."""
-            try:
-                return await super().new(obj)
-            except UniqueViolation as exc:
-                raise DuplicateError(
-                    f"User with handle {obj.handle} already exists."
-                ) from exc
+    async def new(self, user: UserIn) -> UserOut:
+        """Replace default create.one to change input types."""
+        query = sql.SQL("""
+            INSERT INTO {table}(
+                handle,
+                password,
+                full_name,
+                preferred_name
+            )
+            VALUES (
+                {handle},
+                crypt({password}, gen_salt('bf')),
+                {full_name},
+                {preferred_name}
+            )
+            RETURNING id, handle, full_name, preferred_name;
+        """).format(
+            table=self._table,
+            handle=sql.Literal(user.handle),
+            password=sql.Literal(user.password),
+            full_name=sql.Literal(user.full_name),
+            preferred_name=sql.Literal(user.preferred_name),
+        )
 
-    class Update(DummyModel.Update):
-        """Adds password method."""
+        query_result: List[RealDictRow] = await self._client.execute_and_return(query)
 
-        async def password(self, id: UUID, pwd: str) -> UserOut:
-            """Update the password for the User identified by `id`."""
-            raise TodoError()
+        return UserOut(**query_result[0])
 
-    update: Update
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.create = UserModel.Create()
-        self.update = UserModel.Update()
+class UserReader(AsyncRead[UserOut]):
+    """Extended read methods for UserModel."""
+
+    async def one_by_id(self, id_value: UUID) -> UserOut:
+        """Override default behavior to hide password on output."""
+        query = self._query_one_by_id(id_value)
+        query_result = await self._client.execute_and_return(query)
+
+        return create_user_out(query_result[0])
+
+    async def authenticate(self, handle: str, password: str) -> UserOut:
+        """Authorize user via given username & password, return User."""
+        query = sql.SQL("""
+            SELECT
+                id, handle, full_name, preferred_name
+            FROM
+                {table}
+            WHERE
+                handle = {handle} AND
+                password = crypt({password}, password);
+        """).format(
+            table=self._table,
+            handle=sql.Literal(handle),
+            password=sql.Literal(password),
+        )
+
+        query_result = await self._client.execute_and_return(query)
+
+        try:
+            return UserOut(**query_result[0])
+        except IndexError as err:
+            raise NoResultFound from err
+
+
+class UserUpdater(AsyncUpdate[UserOut]):
+    """Extended Updater for UserModel."""
+
+    async def one_by_id(self, id_value: UUID, changes: Dict[str, Any]) -> UserOut:
+        """Un-implemented to force use of update.changes method."""
+        raise NotImplementedError()
+
+    async def changes(self, user_id: UUID, changes: UserChanges) -> UserOut:
+        """Update only the given fields for the given user."""
+
+        def compose_one_change(change: Tuple[str, Any]) -> sql.Composed:
+            key = change[0]
+            value = change[1]
+
+            return sql.SQL("{key} = {value}").format(
+                key=sql.Identifier(key), value=sql.Literal(value)
+            )
+
+        def compose_changes(changes: Dict[str, Any]) -> sql.Composed:
+            return sql.SQL(",").join(
+                [compose_one_change(change) for change in changes.items() if change[1]]
+            )
+
+        query = sql.SQL("""
+            UPDATE {table}
+            SET {changes}
+            WHERE id = {id_value}
+            RETURNING id, handle, full_name, preferred_name;
+        """).format(
+            table=self._table,
+            changes=compose_changes(changes.model_dump()),
+            id_value=sql.Literal(str(user_id)),
+        )
+        query_result = await self._client.execute_and_return(query)
+
+        try:
+            return UserOut(**query_result[0])
+        except IndexError as err:
+            raise NoResultFound from err
+
+    async def password(self, user_id: UUID, new_password: str) -> UserOut:
+        """Update the given user's password."""
+        query = sql.SQL("""
+            UPDATE {table}
+            SET password = crypt({password}, gen_salt('bf'))
+            WHERE id = {user_id}
+            RETURNING id, handle, full_name, preferred_name;
+        """).format(
+            table=self._table,
+            password=sql.Literal(new_password),
+            user_id=sql.Literal(str(user_id)),
+        )
+        query_result = await self._client.execute_and_return(query)
+
+        try:
+            return UserOut(**query_result[0])
+        except IndexError as err:
+            raise NoResultFound from err
+
+
+class UserDeleter(AsyncDelete[UserOut]):
+    """Extend default delete behavior."""
+
+    async def one_by_id(self, id_value: str) -> UserOut:
+        """Override default behavior to hide password on output."""
+        query = self._query_one_by_id(id_value)
+        query_result = await self._client.execute_and_return(query)
+
+        return create_user_out(query_result[0])
+
+
+class UserModel(AsyncModel[UserOut]):
+    """Database queries for User objects."""
+
+    create: UserCreator
+    read: UserReader
+    update: UserUpdater
+    delete: UserDeleter
+
+    def __init__(self, client: AsyncClient) -> None:
+        """Replace built-in Creator & Reader with extended versions."""
+        super().__init__(client, "app_user", UserOut)
+        self.create = UserCreator(client, self.table, UserOut)
+        self.read = UserReader(client, self.table, UserOut)
+        self.update = UserUpdater(client, self.table, UserOut)
+        self.delete = UserDeleter(client, self.table, UserOut)

--- a/backend/src/routers/__init__.py
+++ b/backend/src/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from .account import create_account
 from .status import create_status
+from .token import create_token
 from .user import create_user
 
-__all__ = ["create_status", "create_account", "create_user"]
+__all__ = ["create_status", "create_token", "create_account", "create_user"]

--- a/backend/src/routers/account.py
+++ b/backend/src/routers/account.py
@@ -9,16 +9,16 @@ from src.context import Context
 from src.models import (
     AccountChanges,
     AccountIn,
-    AccountNewDb,
+    AccountNew,
     AccountOut,
     AccountModel,
 )
 
 
-def create_account(_ctx: Context) -> APIRouter:
+def create_account(ctx: Context) -> APIRouter:
     """Create a account router & model with access to the given database."""
     # setup db & Account model
-    model = AccountModel()
+    model = AccountModel(ctx.database)
 
     # set up account router
     account = APIRouter(prefix="/account", tags=["Account"])
@@ -33,7 +33,7 @@ def create_account(_ctx: Context) -> APIRouter:
     async def post(new_account: AccountIn, user_id: UUID) -> AccountOut:
         """Create a new account for given User."""
         return await model.create.new(
-            AccountNewDb(**new_account.model_dump(), user_id=user_id)
+            AccountNew(**new_account.model_dump(), user_id=user_id)
         )
 
     @account.get(
@@ -52,7 +52,7 @@ def create_account(_ctx: Context) -> APIRouter:
         account_id: UUID, changes: AccountChanges, user_id: UUID
     ) -> AccountOut:
         """Update the given account with the given changes."""
-        return await model.update.changes(account_id, changes)
+        return await model.update.changes(account_id, user_id, changes)
 
     @account.put(
         "/{account_id}/closed",
@@ -61,7 +61,9 @@ def create_account(_ctx: Context) -> APIRouter:
     )
     async def put_closed(account_id: UUID, user_id: UUID) -> AccountOut:
         """Mark the given account as closed."""
-        return await model.update.changes(account_id, AccountChanges(closed=True))
+        return await model.update.changes(
+            account_id, user_id, AccountChanges(closed=True)
+        )
 
     @account.get(
         "/closed",

--- a/backend/src/routers/test_account.py
+++ b/backend/src/routers/test_account.py
@@ -1,5 +1,6 @@
 """Tests for /account routes."""
 
+from typing import Any
 import unittest
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -9,8 +10,18 @@ from fastapi.testclient import TestClient
 from src.app import create_app
 from src.models import AccountOut
 
-_TEST_USER_ID = uuid4()
-_TEST_ACCOUNT_ID = uuid4()
+
+def mock_db(result: Any | None, is_side_effect: bool = False):
+    if is_side_effect:
+        return patch(
+            "db_wrapper.AsyncClient.execute_and_return",
+            side_effect=result,
+        )
+
+    return patch(
+        "db_wrapper.AsyncClient.execute_and_return",
+        return_value=result if isinstance(result, list) else [result],
+    )
 
 
 class TestPostAccount(unittest.TestCase):
@@ -22,22 +33,23 @@ class TestPostAccount(unittest.TestCase):
         self.client = TestClient(self.app)
 
     def test_valid_data_returns_201_with_account_out(self) -> None:
-        """POST with valid data returns 201 and an AccountOut with matching fields."""
+        """POST with valid data returns 201 and matching AccountOut."""
+        account_id = uuid4()
+        user_id = uuid4()
+
         expected = AccountOut(
-            id=_TEST_ACCOUNT_ID,
-            user_id=_TEST_USER_ID,
+            id=account_id,
+            user_id=user_id,
             name="Test Account",
             closed=False,
         )
 
-        with patch(
-            "src.models.dummy_model.DummyModel.Create.new",
-            new_callable=AsyncMock,
-            return_value=expected,
+        with mock_db(
+            expected.model_dump(),
         ):
             response = self.client.post(
                 "/account",
-                params={"user_id": str(_TEST_USER_ID)},
+                params={"user_id": str(user_id)},
                 json={"name": "Test Account"},
             )
 
@@ -45,14 +57,15 @@ class TestPostAccount(unittest.TestCase):
         data = response.json()
         self.assertEqual(data["name"], "Test Account")
         self.assertEqual(data["closed"], False)
-        self.assertEqual(data["user_id"], str(_TEST_USER_ID))
+        self.assertEqual(data["user_id"], str(user_id))
         self.assertIn("id", data)
 
     def test_missing_required_field_returns_422(self) -> None:
         """POST without required name field returns 422 with error detail."""
+        user_id = uuid4()
         response = self.client.post(
             "/account",
-            params={"user_id": str(_TEST_USER_ID)},
+            params={"user_id": str(user_id)},
             json={},
         )
 
@@ -83,23 +96,21 @@ class TestGetAccount(unittest.TestCase):
 
     def test_valid_user_id_returns_200_with_account_list(self) -> None:
         """GET with valid user_id returns 200 and a list of AccountOut."""
-        expected = [
-            AccountOut(
-                id=_TEST_ACCOUNT_ID,
-                user_id=_TEST_USER_ID,
-                name="Test Account",
-                closed=False,
-            )
-        ]
+        account_id = uuid4()
+        user_id = uuid4()
+        expected = AccountOut(
+            id=account_id,
+            user_id=user_id,
+            name="Test Account",
+            closed=False,
+        )
 
-        with patch(
-            "src.models.account.AccountModel.Read.many_by_user",
-            new_callable=AsyncMock,
-            return_value=expected,
+        with mock_db(
+            expected.model_dump(),
         ):
             response = self.client.get(
                 "/account",
-                params={"user_id": str(_TEST_USER_ID)},
+                params={"user_id": str(user_id)},
             )
 
         self.assertEqual(response.status_code, 200)
@@ -131,34 +142,35 @@ class TestPutAccountId(unittest.TestCase):
 
     def test_valid_data_returns_200_with_updated_account(self) -> None:
         """PUT with valid data returns 200 and the updated AccountOut."""
+        account_id = uuid4()
+        user_id = uuid4()
         expected = AccountOut(
-            id=_TEST_ACCOUNT_ID,
-            user_id=_TEST_USER_ID,
+            id=account_id,
+            user_id=user_id,
             name="Updated Account",
             closed=False,
         )
 
-        with patch(
-            "src.models.dummy_model.DummyModel.Update.changes",
-            new_callable=AsyncMock,
-            return_value=expected,
+        with mock_db(
+            expected.model_dump(),
         ):
             response = self.client.put(
-                f"/account/{_TEST_ACCOUNT_ID}",
-                params={"user_id": str(_TEST_USER_ID)},
+                f"/account/{account_id}",
+                params={"user_id": str(user_id)},
                 json={"name": "Updated Account"},
             )
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["name"], "Updated Account")
-        self.assertEqual(data["id"], str(_TEST_ACCOUNT_ID))
+        self.assertEqual(data["id"], str(account_id))
 
     def test_invalid_account_id_returns_422(self) -> None:
         """PUT with an invalid account_id path param returns 422 with error detail."""
+        user_id = uuid4()
         response = self.client.put(
             "/account/not-a-valid-uuid",
-            params={"user_id": str(_TEST_USER_ID)},
+            params={"user_id": str(user_id)},
             json={"name": "Updated Account"},
         )
 
@@ -168,8 +180,9 @@ class TestPutAccountId(unittest.TestCase):
 
     def test_missing_user_id_returns_422(self) -> None:
         """PUT without user_id query param returns 422 with error detail."""
+        account_id = uuid4()
         response = self.client.put(
-            f"/account/{_TEST_ACCOUNT_ID}",
+            f"/account/{account_id}",
             json={"name": "Updated Account"},
         )
 
@@ -188,33 +201,34 @@ class TestPutAccountClosed(unittest.TestCase):
 
     def test_valid_account_id_returns_200_with_closed_account(self) -> None:
         """Valid account_id: returns 200 with AccountOut where closed=True."""
+        account_id = uuid4()
+        user_id = uuid4()
         expected = AccountOut(
-            id=_TEST_ACCOUNT_ID,
-            user_id=_TEST_USER_ID,
+            id=account_id,
+            user_id=user_id,
             name="Test Account",
             closed=True,
         )
 
-        with patch(
-            "src.models.dummy_model.DummyModel.Update.changes",
-            new_callable=AsyncMock,
-            return_value=expected,
+        with mock_db(
+            expected.model_dump(),
         ):
             response = self.client.put(
-                f"/account/{_TEST_ACCOUNT_ID}/closed",
-                params={"user_id": str(_TEST_USER_ID)},
+                f"/account/{account_id}/closed",
+                params={"user_id": str(user_id)},
             )
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["closed"], True)
-        self.assertEqual(data["id"], str(_TEST_ACCOUNT_ID))
+        self.assertEqual(data["id"], str(account_id))
 
     def test_invalid_account_id_returns_422(self) -> None:
         """Invalid account_id path param: returns 422 with error detail."""
+        user_id = uuid4()
         response = self.client.put(
             "/account/not-a-valid-uuid/closed",
-            params={"user_id": str(_TEST_USER_ID)},
+            params={"user_id": str(user_id)},
         )
 
         self.assertEqual(response.status_code, 422)
@@ -232,23 +246,21 @@ class TestGetClosedAccounts(unittest.TestCase):
 
     def test_valid_user_id_returns_200_with_closed_account_list(self) -> None:
         """Valid user_id: returns 200 with list of closed AccountOut."""
-        expected = [
-            AccountOut(
-                id=_TEST_ACCOUNT_ID,
-                user_id=_TEST_USER_ID,
-                name="Closed Account",
-                closed=True,
-            )
-        ]
+        account_id = uuid4()
+        user_id = uuid4()
+        expected = AccountOut(
+            id=account_id,
+            user_id=user_id,
+            name="Closed Account",
+            closed=True,
+        )
 
-        with patch(
-            "src.models.account.AccountModel.Read.many_by_user",
-            new_callable=AsyncMock,
-            return_value=expected,
+        with mock_db(
+            expected.model_dump(),
         ):
             response = self.client.get(
                 "/account/closed",
-                params={"user_id": str(_TEST_USER_ID)},
+                params={"user_id": str(user_id)},
             )
 
         self.assertEqual(response.status_code, 200)

--- a/backend/src/routers/test_user.py
+++ b/backend/src/routers/test_user.py
@@ -1,7 +1,8 @@
 """Tests for the /user router endpoints."""
 
+from typing import Any
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
@@ -9,6 +10,19 @@ from fastapi.testclient import TestClient
 from src.app import create_app
 from src.models.user import UserOut
 from src.models.errors import DuplicateError
+
+
+def mock_db(result: Any | None, is_side_effect: bool = False):
+    if is_side_effect:
+        return patch(
+            "db_wrapper.AsyncClient.execute_and_return",
+            side_effect=result,
+        )
+
+    return patch(
+        "db_wrapper.AsyncClient.execute_and_return",
+        return_value=result if isinstance(result, list) else [result],
+    )
 
 
 class TestPostUser(unittest.TestCase):
@@ -25,19 +39,14 @@ class TestPostUser(unittest.TestCase):
         The response body should contain the submitted field values plus a
         newly generated `id` field.
         """
-        user_id = uuid4()
         mock_user = UserOut(
-            id=user_id,
+            id=uuid4(),
             handle="testuser",
             full_name="Test User",
             preferred_name="Test",
         )
 
-        with patch(
-            "src.models.user.UserModel.Create.new",
-            new_callable=AsyncMock,
-            return_value=mock_user,
-        ):
+        with mock_db(mock_user.model_dump()):
             response = self.client.post(
                 "/user",
                 json={
@@ -50,10 +59,8 @@ class TestPostUser(unittest.TestCase):
 
         self.assertEqual(response.status_code, 201)
         data = response.json()
-        self.assertEqual(data["handle"], "testuser")
-        self.assertEqual(data["full_name"], "Test User")
-        self.assertEqual(data["preferred_name"], "Test")
-        self.assertEqual(data["id"], str(user_id))
+        self.assertEqual(UserOut(**data), mock_user)
+        self.assertNotIn("password", data)
 
     def test_missing_fields_returns_422_with_field_details(self) -> None:
         """POST /user with missing required fields returns 422.
@@ -96,10 +103,9 @@ class TestPostUser(unittest.TestCase):
 
     def test_duplicate_handle_returns_409(self) -> None:
         """POST /user with a handle that already exists returns 409."""
-        with patch(
-            "src.models.user.UserModel.Create.new",
-            new_callable=AsyncMock,
-            side_effect=DuplicateError("msg"),
+        with mock_db(
+            DuplicateError("msg"),
+            is_side_effect=True,
         ):
             response = self.client.post(
                 "/user",
@@ -121,9 +127,8 @@ class TestGetUser(unittest.TestCase):
         """Set up the test client with the application."""
         self.app = create_app()
         self.client = TestClient(self.app)
-        self.user_id = uuid4()
         self.mock_user = UserOut(
-            id=self.user_id,
+            id=uuid4(),
             handle="testuser",
             full_name="Test User",
             preferred_name="Test",
@@ -131,19 +136,16 @@ class TestGetUser(unittest.TestCase):
 
     def test_valid_id_returns_200_with_user_out(self) -> None:
         """GET /user with a valid UUID returns 200 and a UserOut body."""
-        with patch(
-            "src.models.dummy_model.DummyModel.Read.one_by_id",
-            new_callable=AsyncMock,
-            return_value=self.mock_user,
+        with mock_db(
+            self.mock_user.model_dump(),
         ):
-            response = self.client.get("/user", params={"user_id": str(self.user_id)})
+            response = self.client.get(
+                "/user", params={"user_id": str(self.mock_user.id)}
+            )
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(data["id"], str(self.user_id))
-        self.assertEqual(data["handle"], "testuser")
-        self.assertEqual(data["full_name"], "Test User")
-        self.assertEqual(data["preferred_name"], "Test")
+        self.assertEqual(UserOut(**data), self.mock_user)
 
     def test_invalid_uuid_returns_422(self) -> None:
         """GET /user with an invalid UUID query parameter returns 422."""
@@ -154,6 +156,19 @@ class TestGetUser(unittest.TestCase):
         invalid_fields = {err["loc"][-1] for err in detail}
         self.assertIn("user_id", invalid_fields)
 
+    def test_missing_id_returns_404(self) -> None:
+        """GET /user with a UUID not in db returns 404."""
+        with mock_db(
+            self.mock_user.model_dump(),
+        ):
+            response = self.client.get(
+                "/user", params={"user_id": str(self.mock_user.id)}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(UserOut(**data), self.mock_user)
+
 
 class TestPutUser(unittest.TestCase):
     """Tests for the PUT /user endpoint."""
@@ -162,9 +177,8 @@ class TestPutUser(unittest.TestCase):
         """Set up the test client with the application."""
         self.app = create_app()
         self.client = TestClient(self.app)
-        self.user_id = uuid4()
         self.mock_user = UserOut(
-            id=self.user_id,
+            id=uuid4(),
             handle="updateduser",
             full_name="Updated User",
             preferred_name="Updated",
@@ -172,20 +186,18 @@ class TestPutUser(unittest.TestCase):
 
     def test_valid_handle_update_returns_200_with_updated_user_out(self) -> None:
         """PUT /user with a valid handle change returns 200 and updated UserOut body."""
-        with patch(
-            "src.models.dummy_model.DummyModel.Update.changes",
-            new_callable=AsyncMock,
-            return_value=self.mock_user,
+        with mock_db(
+            self.mock_user.model_dump(),
         ):
             response = self.client.put(
                 "/user",
-                params={"user_id": str(self.user_id)},
+                params={"user_id": str(self.mock_user.id)},
                 json={"handle": "updateduser"},
             )
 
-        self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(data["id"], str(self.user_id))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["id"], str(self.mock_user.id))
         self.assertEqual(data["handle"], "updateduser")
 
     def test_invalid_uuid_returns_422(self) -> None:
@@ -209,9 +221,8 @@ class TestDeleteUser(unittest.TestCase):
         """Set up the test client with the application."""
         self.app = create_app()
         self.client = TestClient(self.app)
-        self.user_id = uuid4()
         self.mock_user = UserOut(
-            id=self.user_id,
+            id=uuid4(),
             handle="testuser",
             full_name="Test User",
             preferred_name="Test",
@@ -219,18 +230,16 @@ class TestDeleteUser(unittest.TestCase):
 
     def test_valid_id_returns_200_with_deleted_user_out(self) -> None:
         """DELETE /user with a valid UUID returns 200 and the deleted UserOut body."""
-        with patch(
-            "src.models.dummy_model.DummyModel.Delete.one_by_id",
-            new_callable=AsyncMock,
-            return_value=self.mock_user,
+        with mock_db(
+            self.mock_user.model_dump(),
         ):
             response = self.client.delete(
-                "/user", params={"user_id": str(self.user_id)}
+                "/user", params={"user_id": str(self.mock_user.id)}
             )
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(data["id"], str(self.user_id))
+        self.assertEqual(data["id"], str(self.mock_user.id))
         self.assertEqual(data["handle"], "testuser")
 
     def test_invalid_uuid_returns_422(self) -> None:
@@ -260,10 +269,8 @@ class TestPutPassword(unittest.TestCase):
 
     def test_valid_request_returns_200_with_user_out(self) -> None:
         """PUT /user/password with valid data returns 200 and a UserOut body."""
-        with patch(
-            "src.models.user.UserModel.Update.password",
-            new_callable=AsyncMock,
-            return_value=self.mock_user,
+        with mock_db(
+            self.mock_user.model_dump(),
         ):
             response = self.client.put(
                 "/user/password",

--- a/backend/src/routers/user.py
+++ b/backend/src/routers/user.py
@@ -1,10 +1,9 @@
 """Routes under `/user`."""
 
-from src.models.errors import DuplicateError
-
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import status as status_code
+from fastapi import status as status_code, Depends
 from fastapi.exceptions import HTTPException
 from fastapi.routing import APIRouter
 from pydantic import BaseModel
@@ -16,6 +15,8 @@ from src.models import (
     UserOut,
     UserModel,
 )
+from src.models.errors import DuplicateError
+from src.security import create_auth_dep
 
 
 class PasswordChange(BaseModel):
@@ -27,6 +28,7 @@ class PasswordChange(BaseModel):
 def create_user(ctx: Context) -> APIRouter:
     """Create a user router & model from given config."""
     model = UserModel(ctx.database)
+    auth_user = create_auth_dep(ctx.database, ctx.jwt_key)
 
     user = APIRouter(prefix="/user", tags=["User"])
 
@@ -49,7 +51,7 @@ def create_user(ctx: Context) -> APIRouter:
     @user.get(
         "", response_model=UserOut, summary="Get the currently authenticated User."
     )
-    async def get_user(user_id: UUID) -> UserOut:
+    async def get_user(user_id: Annotated[UUID, Depends(auth_user)]) -> UserOut:
         """Get the current user's information."""
         return await model.read.one_by_id(user_id)
 
@@ -58,7 +60,9 @@ def create_user(ctx: Context) -> APIRouter:
         response_model=UserOut,
         summary="Update the currently authenticated User's information.",
     )
-    async def put_user(changes: UserChanges, user_id: UUID) -> UserOut:
+    async def put_user(
+        changes: UserChanges, user_id: Annotated[UUID, Depends(auth_user)]
+    ) -> UserOut:
         """Update the current user's information."""
         return await model.update.changes(user_id, changes)
 
@@ -68,7 +72,7 @@ def create_user(ctx: Context) -> APIRouter:
         summary="Update the currently authenticated User's password.",
     )
     async def put_password(
-        user_id: UUID,
+        user_id: Annotated[UUID, Depends(auth_user)],
         password_change: PasswordChange,
     ) -> UserOut:
         """Update the current user's password."""
@@ -79,7 +83,7 @@ def create_user(ctx: Context) -> APIRouter:
     @user.delete(
         "", response_model=UserOut, summary="Delete the currently authenticated User."
     )
-    async def delete_user(user_id: UUID) -> UserOut:
+    async def delete_user(user_id: Annotated[UUID, Depends(auth_user)]) -> UserOut:
         """Delete the current user from the database."""
         return await model.delete.one_by_id(str(user_id))
 

--- a/backend/src/routers/user.py
+++ b/backend/src/routers/user.py
@@ -26,7 +26,7 @@ class PasswordChange(BaseModel):
 
 def create_user(ctx: Context) -> APIRouter:
     """Create a user router & model from given config."""
-    model = UserModel()
+    model = UserModel(ctx.database)
 
     user = APIRouter(prefix="/user", tags=["User"])
 
@@ -81,6 +81,6 @@ def create_user(ctx: Context) -> APIRouter:
     )
     async def delete_user(user_id: UUID) -> UserOut:
         """Delete the current user from the database."""
-        return await model.delete.one_by_id(user_id)
+        return await model.delete.one_by_id(str(user_id))
 
     return user

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -66,6 +66,7 @@ dependencies = [
     { name = "db-wrapper" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-swagger" },
+    { name = "pyjwt" },
 ]
 
 [package.dev-dependencies]
@@ -79,6 +80,7 @@ requires-dist = [
     { name = "db-wrapper", git = "https://github.com/andrew-chang-dewitt/lib-python-db-wrapper" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "fastapi-swagger", specifier = ">=0.4.48" },
+    { name = "pyjwt", specifier = ">=2.12.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -573,6 +575,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     container_name: finance_backend
     ports: # mapping local machine port -> container port
       - "8000:8000"
-
     environment: # environment variables passed into backend
       - API_ROOT_PATH=
       - DB_HOST=db      # IMPORTANT: use service name "db"
@@ -15,5 +14,11 @@ services:
       - DB_NAME=finance
       - DB_USER=postgres
       - DB_PASSWORD=postgres
+    secrets:
+      - app_key
     depends_on: # ensures database starts before the backend
       - db
+
+secrets:
+  app_key:
+    file: .secrets/app_key.txt


### PR DESCRIPTION
Alters existing `/user` & `/account` routes to use auth provider on protected route & provides user_id automatically with successful authentication. 

- depends on #68 

TODO:

- [ ] fix failing tests--now failing because no token provided for user id & auth, needs some sort of mock token provider